### PR TITLE
Make callback listener public

### DIFF
--- a/src/Resources/config/listener.yml
+++ b/src/Resources/config/listener.yml
@@ -31,6 +31,7 @@ services:
 
   eblick_contao_trigger.listener.datacontainer.trigger_log:
     class: 'EBlick\ContaoTrigger\EventListener\DataContainer\ExecutionLog'
+    public: true
 
   eblick_contao_trigger.listener.datacontainer.table_condition:
     class: 'EBlick\ContaoTrigger\EventListener\DataContainer\TableCondition'


### PR DESCRIPTION
Because it is used as callback.