### PR TITLE
Fix time formatting bug in TableCondition

### DIFF
--- a/src/Component/Condition/TableCondition.php
+++ b/src/Component/Condition/TableCondition.php
@@ -255,7 +255,7 @@ class TableCondition implements ConditionInterface, DataContainerComponentInterf
             if ($trigger->cnd_table_overwriteExecutionTime) {
                 $timeComparisonSql = 'CONCAT(DATE('.$timeComparisonSql.'), ?)';
 
-                $params[] = ' '.date('H:m:s', (int) $trigger->cnd_table_executionTime);
+                $params[] = ' '.date('H:i:s', (int) $trigger->cnd_table_executionTime);
                 $types[] = ParameterType::STRING;
             }
 

--- a/tests/Component/Condition/TableConditionTest.php
+++ b/tests/Component/Condition/TableConditionTest.php
@@ -98,4 +98,34 @@ class TableConditionTest extends TestCase
 
         self::assertEquals($result, ['testCol1' => null, 'testCol2' => null, 'testCol3' => null]);
     }
+
+    public function testBuildQueryFormatsExecutionTime(): void
+    {
+        $reflection = new \ReflectionClass(TableCondition::class);
+        $method = $reflection->getMethod('buildQuery');
+        $method->setAccessible(true);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+        $connection->method('quoteIdentifier')->willReturnCallback(static fn ($v) => '`'.$v.'`');
+
+        $condition = new TableCondition($connection, $this->createMock(RowDataCompiler::class));
+
+        $trigger = (object) [
+            'cnd_table_src' => 'test',
+            'cnd_table_timed' => true,
+            'cnd_table_timeColumn' => 'myTime',
+            'cnd_table_timeOffset' => 0,
+            'cnd_table_timeOffsetUnit' => 'DAY',
+            'cnd_table_overwriteExecutionTime' => true,
+            'cnd_table_executionTime' => strtotime('07:30:00'),
+            'cnd_table_expression' => '',
+        ];
+
+        [$query, $params] = $method->invoke($condition, $trigger, []);
+
+        $this->assertSame(' '.date('H:i:s', (int) $trigger->cnd_table_executionTime), $params[1]);
+    }
 }


### PR DESCRIPTION
## Summary
- fix incorrect time format when building SQL queries
- test that execution time is formatted with minutes correctly

## Testing
- `phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430e0392708322a0f077119de5747c